### PR TITLE
Correct tfproviderlint path

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-sh -c "/app/tfproviderlint $*"
+sh -c "/usr/bin/tfproviderlint $*"


### PR DESCRIPTION
the commit in bflad/tfproviderlint@7b34aae862093a7 changed the path of tfproviderlint from /app to /usr/bin, so do that here too.